### PR TITLE
fix: compatibility with REPO v0.4.3.2

### DIFF
--- a/EmoteLauncher.cs
+++ b/EmoteLauncher.cs
@@ -151,22 +151,29 @@ namespace SomeEmotesREPO
 
         public void InitTexturesFrom(GameObject initial)
         {
-            if (leg_R != null) leg_R.materials = GetMaterialsFromBone(initial, "mesh_leg_r");
-            if (leg_L != null) leg_L.materials = GetMaterialsFromBone(initial, "mesh_leg_l");
-            if (body_bot != null) body_bot.materials = GetMaterialsFromBone(initial, "mesh_body_bot");
-            if (body_top_sphere != null) body_top_sphere.materials = GetMaterialsFromBone(initial, "mesh_body_top_sphere");
-            if (arm_L != null) arm_L.materials = GetMaterialsFromBone(initial, "mesh_arm_l");
-            if (arm_R != null) arm_R.materials = GetMaterialsFromBone(initial, "mesh_arm_r");
-            if (health_LED != null) health_LED.materials = GetMaterialsFromBone(initial, "mesh_health");
-            if (health_frame != null) health_frame.materials = GetMaterialsFromBone(initial, "mesh_health frame");
-            if (health_shadow != null) health_shadow.materials = GetMaterialsFromBone(initial, "mesh_health shadow");
-            if (head_bot_sphere != null) head_bot_sphere.materials = GetMaterialsFromBone(initial, "mesh_head_bot_sphere");
-            if (head_bot_flat != null) head_bot_flat.materials = GetMaterialsFromBone(initial, "mesh_head_bot_flat");
-            if (head_top != null) head_top.materials = GetMaterialsFromBone(initial, "mesh_head_top");
-            if (eye_L != null) eye_L.materials = GetMaterialsFromBone(initial, "mesh_eye_l");
-            if (iris_L != null) iris_L.materials = GetMaterialsFromBone(initial, "mesh_pupil_l");
-            if (eye_R != null) eye_R.materials = GetMaterialsFromBone(initial, "mesh_eye_r");
-            if (iris_R != null) iris_R.materials = GetMaterialsFromBone(initial, "mesh_pupil_r");
+            TryCopyMaterials(leg_R, initial, "mesh_leg_r");
+            TryCopyMaterials(leg_L, initial, "mesh_leg_l");
+            TryCopyMaterials(body_bot, initial, "mesh_body_bot");
+            TryCopyMaterials(body_top_sphere, initial, "mesh_body_top_sphere");
+            TryCopyMaterials(arm_L, initial, "mesh_arm_l");
+            TryCopyMaterials(arm_R, initial, "mesh_arm_r");
+            TryCopyMaterials(health_LED, initial, "mesh_health");
+            TryCopyMaterials(health_frame, initial, "mesh_health frame");
+            TryCopyMaterials(health_shadow, initial, "mesh_health shadow");
+            TryCopyMaterials(head_bot_sphere, initial, "mesh_head_bot_sphere");
+            TryCopyMaterials(head_bot_flat, initial, "mesh_head_bot_flat");
+            TryCopyMaterials(head_top, initial, "mesh_head_top");
+            TryCopyMaterials(eye_L, initial, "mesh_eye_l");
+            TryCopyMaterials(iris_L, initial, "mesh_pupil_l");
+            TryCopyMaterials(eye_R, initial, "mesh_eye_r");
+            TryCopyMaterials(iris_R, initial, "mesh_pupil_r");
+        }
+
+        void TryCopyMaterials(SkinnedMeshRenderer target, GameObject source, string boneName)
+        {
+            if (target == null) return;
+            var materials = GetMaterialsFromBone(source, boneName);
+            if (materials != null) target.materials = materials;
         }
 
         Material[] GetMaterialsFromBone(GameObject initial, string name)

--- a/EmoteSystem.cs
+++ b/EmoteSystem.cs
@@ -151,10 +151,9 @@ namespace SomeEmotesREPO
         [PunRPC]
         private void RPC_PlayEmote(string emoteId, float _initialRot)
         {
-            // Ignores if emotes are disabled by the client
-            //if (!PV.IsMine && SomeEmotesREPO.ConfigActiveEmoteSystem.Value == false) return;
-
             IsEmoting = true;
+
+            if (emoteLauncher == null) return;
 
             emoteLauncher.SetRotation(_initialRot);
             emoteLauncher.Animate(emoteId);
@@ -166,7 +165,10 @@ namespace SomeEmotesREPO
         {
             IsEmoting = false;
 
-            emoteLauncher.StopEmote();
+            if (emoteLauncher != null)
+            {
+                emoteLauncher.StopEmote();
+            }
         }
 
         void Update()

--- a/PlayerAvatarVisualsPatch.cs
+++ b/PlayerAvatarVisualsPatch.cs
@@ -30,6 +30,9 @@ namespace SomeEmotesREPO
     {
         static void Prefix(PlayerAvatarVisuals __instance)
         {
+            if (!EmoteSystem.Ready || EmoteSystem.Instance == null) return;
+            if (!EmoteSystem.Instance.IsEmoting) return;
+
             EmoteSystem.Instance.StopEmote();
         }
     }

--- a/SomeEmotesREPO.cs
+++ b/SomeEmotesREPO.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace SomeEmotesREPO;
 
-[BepInPlugin("ImGogole.SomeEmotesREPO", "SomeEmotesREPO", "1.0.4")]
+[BepInPlugin("ImGogole.SomeEmotesREPO", "SomeEmotesREPO", "1.0.7")]
 public class SomeEmotesREPO : BaseUnityPlugin
 {
     internal static SomeEmotesREPO Instance { get; private set; } = null!;

--- a/SomeEmotesREPO.csproj
+++ b/SomeEmotesREPO.csproj
@@ -4,7 +4,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <Authors>ImGogole</Authors>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
   "name": "SomeEmotesREPO",
-  "version_number": "1.0.6",
+  "version_number": "1.0.7",
   "website_url": "https://github.com/imgogole/some-emotes-repo",
   "description": "Dances and emotes with SomeEmotesREPO emote system !",
   "dependencies":
   [
-    "BepInEx-BepInExPack-5.4.2100"
+    "BepInEx-BepInExPack-5.4.2305"
   ]
 }


### PR DESCRIPTION
## Summary
Updates SomeEmotesREPO to work with REPO v0.4.3.2. Fixes crashes on game join caused by null references in RPC handlers and material copy system.
## Changes
### Fix crashes
- **`EmoteSystem.cs`** — Added null checks for `emoteLauncher` in `RPC_StopEmote()` and `RPC_PlayEmote()`. The launcher is assigned 0.75s after game join via `SetVisuals` coroutine; RPCs arriving before assignment no longer crash.
- **`PlayerAvatarVisualsPatch.cs`** — Added validation for `EmoteSystem.Ready` and `Instance` before calling `StopEmote()` in the Revive patch, preventing NPE when revive triggers during initialization.
- **`EmoteLauncher.cs`** — Refactored `InitTexturesFrom()` to use a `TryCopyMaterials()` helper that skips meshes not found in the player model instead of assigning null materials. Fixes `ArgumentNullException` on `Renderer.set_materials` when mesh names differ between versions.
### Version bump to v1.0.7
| File | Change |
|---|---|
| `SomeEmotesREPO.cs` | `[BepInPlugin]` version `1.0.4` → `1.0.7` |
| `SomeEmotesREPO.csproj` | `<Version>` `1.0.6` → `1.0.7` |
| `manifest.json` | `version_number` + BepInEx `5.4.2100` → `5.4.2305` |
## Files changed
- `EmoteSystem.cs` — Null checks in RPC handlers
- `PlayerAvatarVisualsPatch.cs` — Validation before StopEmote on revive
- `EmoteLauncher.cs` — Null-safe material copy via TryCopyMaterials
- `SomeEmotesREPO.cs` — Plugin version string
- `SomeEmotesREPO.csproj` — Assembly version
- `manifest.json` — Mod version + BepInEx dependency
## Tested
- REPO v0.4.3.2 | BepInEx 5.4.2305 | Steam
- Private lobby with friends (multiplayer)
- Emote panel opens with P key, emotes play and sync correctly
- No crashes on revive/death
- No NullReferenceException or ArgumentNullException in BepInEx logs